### PR TITLE
Improve training efficiency

### DIFF
--- a/model.py
+++ b/model.py
@@ -5,7 +5,11 @@ from transformers import AutoModel, AutoImageProcessor
 class DinoV2Regressor(nn.Module):
     def __init__(self, output_dim=6, model_name='facebook/dinov2-base'):
         super(DinoV2Regressor, self).__init__()
-        self.processor = AutoImageProcessor.from_pretrained(model_name)
+        self.processor = AutoImageProcessor.from_pretrained(
+            model_name,
+            do_rescale=False,
+            use_fast=True,
+        )
         self.backbone = AutoModel.from_pretrained(model_name)
         backbone_dim = self.backbone.config.hidden_size
         


### PR DESCRIPTION
## Summary
- add per-element weighted SmoothL1 loss
- enable cuDNN benchmark for better GPU usage
- load HuggingFace image processor with `do_rescale=False` and `use_fast=True`
- pin dataloader memory and add workers
- move tensors to device non-blocking

## Testing
- `pytest -q` *(fails: no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_683ebaf57c6c8327b4eb4e4f7b39b6a6